### PR TITLE
Update setPort to setMessagePort

### DIFF
--- a/sdk_files/source/BrazeSDK.brs
+++ b/sdk_files/source/BrazeSDK.brs
@@ -1117,7 +1117,7 @@ function BrazeInit(config as object, messagePort as object)
     postToUrl: function(url as string, postJson as object, headers = [] as object) as object
       request = CreateObject("roUrlTransfer")
       port = CreateObject("roMessagePort")
-      request.SetPort(port)
+      request.SetMessagePort(port)
       request.SetCertificatesFile("common:/certs/ca-bundle.crt")
       request.InitClientCertificates()
       request.SetUrl(url)

--- a/torchietv/source/BrazeSDK.brs
+++ b/torchietv/source/BrazeSDK.brs
@@ -1117,7 +1117,7 @@ function BrazeInit(config as object, messagePort as object)
     postToUrl: function(url as string, postJson as object, headers = [] as object) as object
       request = CreateObject("roUrlTransfer")
       port = CreateObject("roMessagePort")
-      request.SetPort(port)
+      request.SetMessagePort(port)
       request.SetCertificatesFile("common:/certs/ca-bundle.crt")
       request.InitClientCertificates()
       request.SetUrl(url)


### PR DESCRIPTION
The setPort function is no longer supported by Roku and have been removed from their documentation. It will still function but has been depreciated for setMessagePort